### PR TITLE
Add fileExtension property to architecture plugins

### DIFF
--- a/src/architectures/anna/plugin.js
+++ b/src/architectures/anna/plugin.js
@@ -7,6 +7,7 @@ import {AnnaCodeFormatter} from "@/architectures/anna/formatter.js";
 
 export default {
     name: "anna",
+    fileExtension: "asm",
     parser: new AnnaAssemblyParser(),
     emulator: new AnnaEmulator(),
     setupBlockBlocks: setupBlocklyBlocks,

--- a/src/architectures/armlet/plugin.js
+++ b/src/architectures/armlet/plugin.js
@@ -10,6 +10,7 @@ const instructionFactory = new ArmletInstructionFactory();
 
 export default {
     name: "armlet",
+    fileExtension: "s",
     parser: new ArmletAssemblyParser(instructionFactory),
     emulator: new ArmletEmulator(),
     setupBlockBlocks: setupBlocklyBlocks,

--- a/src/architectures/scott/plugin.js
+++ b/src/architectures/scott/plugin.js
@@ -7,6 +7,7 @@ import {toolbox} from "@/architectures/scott/toolbox.js";
 
 export default {
     name: "scott",
+    fileExtension: "asm",
     parser: new ScottAssemblyParser(),
     emulator: new ScottEmulator(),
     setupBlockBlocks: setupBlocklyBlocks,

--- a/src/architectures/simpleRISC/plugin.js
+++ b/src/architectures/simpleRISC/plugin.js
@@ -7,6 +7,7 @@ import {SimpleRISCParser} from "@/architectures/simpleRISC/parser.js";
 
 export default {
     name: "simpleRISC",
+    fileExtension: "asm",
     parser: new SimpleRISCParser(),
     emulator: new SimpleRISCEmulator(),
     setupBlockBlocks: setupBlocklyBlocks,

--- a/src/components/BlocksemblerNavigation.vue
+++ b/src/components/BlocksemblerNavigation.vue
@@ -8,7 +8,13 @@ import CloudDownloadIcon from "@/components/icons/CloudDownloadIcon.vue";
 let emit = defineEmits(['importProject', 'exportProject']);
 
 let exportProject = () => {
-  saveAs(new Blob([codingWorkspaceState.sourceCode]), `project-${Date.now()}.s`);
+  let fileExtension = "asm";
+
+  if ("fileExtension" in codingWorkspaceState.archPlugin) {
+    fileExtension = codingWorkspaceState.archPlugin.fileExtension;
+  }
+
+  saveAs(new Blob([codingWorkspaceState.sourceCode]), `project-${Date.now()}.${fileExtension}`);
   logEvent('buttonClick', {'source': 'exportProjectButton'})
 }
 


### PR DESCRIPTION
Introduced a fileExtension property to each architecture plugin to dynamically determine export file extensions. Updated the export logic in BlocksemblerNavigation to utilize the plugin's fileExtension for creating appropriately named export files.